### PR TITLE
add: hook to patch blog date display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 site/
+__pycache__/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,9 @@ plugins:
       blog_dir: blog
   - blog:
       blog_dir: exp
-      post_date_format: yyyy/MM/dd
+      # post_date_format: yyyy MMMM
+      # Due to a bug in the plugin, this option doesn't work per instance basis.
+      # The patch_blog_date.py hook applies the date format for this instance.
       post_readtime: false
       authors: false
       archive_name: Annual recap
@@ -57,5 +59,5 @@ extra:
       link: https://www.linkedin.com/company/nypesap
     - icon: fontawesome/brands/twitter
       link: http://twitter.com/nypesap
-     
-  
+hooks:
+  - overrides/hooks/patch_blog_date.py  # Sets the proper date format for "exp" blog instance.

--- a/overrides/hooks/patch_blog_date.py
+++ b/overrides/hooks/patch_blog_date.py
@@ -1,0 +1,75 @@
+"""MkDocs hook, which patches the display of the date in the blog.
+
+By default when using multiple blog instances the `post_date_format` option of the last instance
+modifies the date format for all instances. 
+The patch replaces the date processor between pages to avoid the need to modify the template.
+
+MIT Licence 2024 Kamil Krzyśków (HRY) for Nype (npe.cm)
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from babel.dates import format_date, format_datetime
+from jinja2 import Environment
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.plugins import PrefixedLogger, event_priority
+
+# region Core Logic Events
+
+_ENV_REF = None
+_BLOG_FILTER_REF = None
+_CUSTOM_FILTER_REF = None
+
+
+# Run after the blog plugin
+@event_priority(-100)
+def on_env(env: Environment, *, config: MkDocsConfig, **__) -> Optional[Environment]:
+    """Main function. Triggers just before the build begins."""
+    global _ENV_REF
+    global _BLOG_FILTER_REF
+    global _CUSTOM_FILTER_REF
+
+    def custom_date_filter(date):
+        return _format_date(date, "yyyy MMMM", config)
+
+    _CUSTOM_FILTER_REF = custom_date_filter
+    _BLOG_FILTER_REF = env.filters["date"]
+    _ENV_REF = env
+
+    LOG.info("New blog date filter has been saved")
+
+
+@event_priority(-100)
+def on_page_context(context, page, config, nav):
+    """Depending on the page replace the filter"""
+    if page.url.startswith("exp/"):
+        LOG.debug("Custom filter applied")
+        _ENV_REF.filters["date"] = _CUSTOM_FILTER_REF
+    else:
+        LOG.debug("Blog filter applied")
+        _ENV_REF.filters["date"] = _BLOG_FILTER_REF
+
+
+def _format_date(date: datetime, format: str, config: MkDocsConfig):
+    """Copied from the blog plugin"""
+    locale: str = config.theme["language"].replace("-", "_")
+    if format in ["full", "long", "medium", "short"]:
+        return format_date(date, format=format, locale=locale)
+    else:
+        return format_datetime(date, format=format, locale=locale)
+
+
+# endregion
+
+
+# region Constants
+
+HOOK_NAME: str = "fix_blog_date"
+"""Name of this hook. Used in logging."""
+
+LOG: PrefixedLogger = PrefixedLogger(HOOK_NAME, logging.getLogger(f"mkdocs.hooks.{HOOK_NAME}"))
+"""Logger instance for this hook."""
+
+# endregion


### PR DESCRIPTION
The `post_date_format` option of the Blog plugin isn't instance aware, as in, the last instance overwrites the `date` filter for the whole jinja2 environment, so all instances use the date format from the last instance.

As the date filter is used in the templates the initial idea to fix it was to modify the templates themselves to use a modified injected date filter. However, extending the `on_page_context` event with the reference to the created environment, allows to replace the `date` filter based on the information available to the page, like the URL that has an unique beginning for each blog instance, so no modification to the templates is necessary.